### PR TITLE
Don't exit abruptly and allow other handlers to be run.

### DIFF
--- a/KernelExceptionListener.php
+++ b/KernelExceptionListener.php
@@ -3,6 +3,7 @@
 namespace Kutny\TracyBundle;
 
 use Exception;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -24,7 +25,10 @@ class KernelExceptionListener
 
         if (!$this->isNotFoundException($exception) && !$this->isAccessDeniedHttpException($exception)) {
             Debugger::$logDirectory = $this->logDirectory;
+            ob_start();
             Debugger::_exceptionHandler($exception, true);
+            $event->setResponse(new Response(ob_get_contents()));
+            ob_clean();
         }
     }
 


### PR DESCRIPTION
Tracy exits right after it's done. This means that no other exception handlers will be run after this one.
This patch allows other handlers to be run.
