### PR TITLE
The bundle should be configured on a boot, otherwise some erros could not be cought.

### DIFF
--- a/KernelExceptionListener.php
+++ b/KernelExceptionListener.php
@@ -11,25 +11,12 @@ use Tracy\Debugger;
 
 class KernelExceptionListener
 {
-    /** string */
-    private $logDirectory;
-
-    private $emails;
-
-    public function __construct($logDirectory, array $emails)
-    {
-        $this->logDirectory = $logDirectory;
-        $this->emails = $emails;
-    }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
         $exception = $event->getException();
 
         if (!$this->isNotFoundException($exception) && !$this->isAccessDeniedHttpException($exception)) {
-            Debugger::$logDirectory = $this->logDirectory;
-            Debugger::$email = $this->emails;
-
             ob_start();
             Debugger::_exceptionHandler($exception, true);
             $event->setResponse(new Response(ob_get_contents()));

--- a/KutnyTracyBundle.php
+++ b/KutnyTracyBundle.php
@@ -2,14 +2,16 @@
 
 namespace Kutny\TracyBundle;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Tracy\Debugger;
 
 class KutnyTracyBundle extends Bundle
 {
 
-    public function build(ContainerBuilder $container)
+    public function boot()
     {
+        Debugger::$logDirectory = $this->container->getParameter('kutny_tracy.exceptions_directory');
+        Debugger::$email = $this->container->getParameter('kutny_tracy.emails');
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Installation
 }
 ~~~~~
 
-2) Add KutnyTracyBundle to your application kernel
+2) Add KutnyTracyBundle to your application kernel.
+For This bundle to catch as many errors as possible it should be the first bundle in the bundles array.
 
 ~~~~~ php
 // app/AppKernel.php
 public function registerBundles()
 {
     return array(
-        // ...
         new Kutny\TracyBundle\KutnyTracyBundle(),
         // ...
     );

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,8 +6,6 @@
 
     <services>
         <service id="kutny_tracy_kernel_exception_listener" class="Kutny\TracyBundle\KernelExceptionListener">
-            <argument>%kutny_tracy.exceptions_directory%</argument>
-            <argument>%kutny_tracy.emails%</argument>
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException"/>
         </service>
     </services>


### PR DESCRIPTION
The way we configure the Tracy:
1. is way to late.
2. Won't catch/log normal errors

This PR fixes that by moving an Tracy configuration into the bundle boot and by fixing a documentation where it recommends the  bundle be the first one registered.
