### PR TITLE
Add ignored Exceptions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('store_username_in_server_variable')
                     ->defaultNull()
                 ->end()
+                ->arrayNode('ignored_exceptions')
+                    ->prototype('scalar')->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/KutnyTracyExtension.php
+++ b/DependencyInjection/KutnyTracyExtension.php
@@ -40,6 +40,38 @@ class KutnyTracyExtension extends Extension
 
             $fs->mkdir($dir);
         }
+
+        $defaultIgnoredExceptions = array(
+            'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException',
+            'Symfony\Component\HttpKernel\Exception\NotFoundHttpException',
+        );
+
+        foreach ($defaultIgnoredExceptions as $exception) {
+            if (!in_array($exception, $config['ignored_exceptions'], true)) {
+                $config['ignored_exceptions'][] = $exception;
+            }
+        }
+
+        foreach ($config['ignored_exceptions'] as $exception) {
+            $this->testExceptionExists($exception);
+        }
+
+        sort($config['ignored_exceptions']);
+        
+        $container->setParameter('kutny_tracy.ignored_exceptions', array_fill_keys($config['ignored_exceptions'], 1));
     }
 
+    /**
+     * Checks if an exception is loadable.
+     *
+     * @param string $exception Class to test
+     *
+     * @throws \InvalidArgumentException if the class was not found.
+     */
+    private function testExceptionExists($exception)
+    {
+        if (!is_subclass_of($exception, '\Exception') && !is_a($exception, '\Exception', true)) {
+            throw new \InvalidArgumentException("KutnyTracyBundle exception mapper: Could not load class '$exception' or the class does not extend from '\Exception'. Most probably this is a configuration problem.");
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ kutny_tracy:
     emails: ['errors@mycompany.com'] # error notification recipients
     exceptions_directory: <directory> # optional, default directory set to %kernel.logs_dir%/exceptions
     store_username_in_server_variable: true|false # optional, default value = false; stores username of logged user in $_SERVER['SYMFONY_USERNAME'] - helps you to find out which user encountered the error
+    ignored_exceptions:
+        - Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+        - RuntimeException
+        - UnexpectedValueException
 
 ~~~~~
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,6 +8,7 @@
         <service id="kutny_tracy_kernel_exception_listener" class="Kutny\TracyBundle\KernelExceptionListener">
             <argument>%kutny_tracy.store_username_in_server_variable%</argument>
             <argument type="service" id="security.context" />
+            <argument>%kutny_tracy.ignored_exceptions%</argument>
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException"/>
             <tag name="kernel.event_listener" event="console.exception" method="onConsoleException"/>
         </service>


### PR DESCRIPTION
I've replaced the two exceptions that are ignored now by a feature called ignored exceptions. That are the exceptions that tracy should ignore.
This is useful when you have an api and you are returning something like BadRequest qhen the consumer has done something wrong.