### PR TITLE
Configuration: Allow empty emails

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('emails')
-                    ->isRequired()
+                    ->defaultValue(array())
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('exceptions_directory')


### PR DESCRIPTION
Right know, when I want to use bundle out of the box, I get this error:

![image](https://cloud.githubusercontent.com/assets/924196/16179886/27e96ce0-3674-11e6-924a-fede66693808.png)

I don't want to use any emails, just see the debug screen.

What is the reason to enforce it?


This PR should make it work even without emails.
