### PR TITLE
Set priority

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,8 +9,8 @@
             <argument>%kutny_tracy.store_username_in_server_variable%</argument>
             <argument type="service" id="security.token_storage" on-invalid="null"/>
             <argument>%kutny_tracy.ignored_exceptions%</argument>
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException"/>
-            <tag name="kernel.event_listener" event="console.exception" method="onConsoleException"/>
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-1"/>
+            <tag name="kernel.event_listener" event="console.exception" method="onConsoleException" priority="-1"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
If we don't set priority to -1 in 3.3 this listener gets called before the FirewallException listener.
This is problematic as the way listeners are called is different in sf 3.3 and this one gets called first and this means that if one opens the url that doesn't have permissions to it's not redirected to login page but 403 error is thrown.

I hope that we won't break something else with this.