### PR TITLE
Drop symfony/security dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "tracy/tracy": "2.3.*",
-        "symfony/security": "~2.6|~3.0"
+        "tracy/tracy": "2.3.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
As far as I can tell Symfony/Security doesn't seem to be necessary.