### PR TITLE
Support newer versions of tracy.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "tracy/tracy": "2.3.*",
+        "tracy/tracy": "~2.3",
         "symfony/security": "~2.6|~3.0"
     },
     "autoload": {


### PR DESCRIPTION
They use semantic versioning so this bundle should work out of the box with all versions > 2.3 && < 3.0.