### PR TITLE
To use updated error handler signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "tracy/tracy": "~2.3",
+        "tracy/tracy": "~2.4",
         "symfony/security": "~2.6|~3.0|~4.0"
     },
     "autoload": {


### PR DESCRIPTION
The Symfony registers the error handler callback with 4 required parameters. The 5th one optional and also deprecated in PHP 7.2. The tracy 2.4 handles this properly.